### PR TITLE
Migrate from backing up to s3 to GCS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM amazon/aws-cli:latest
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
 ARG POSTGRES_VERSION
 
-RUN yum update -y \
-    && yum install -y gzip
+RUN yum update -y && yum install -y gzip
 
 WORKDIR /scripts
 COPY install-pg-dump.sh .

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
-# Deploy a Cron Job to Backup PostgreSQL to Amazon S3
+# Deploy a Render Cron Job to Backup PostgreSQL to Google Cloud Storage
 
-This repo can be used to deploy a [Cron Job](https://render.com/docs/cronjobs) on [Render](https://render.com) to backup a PostgreSQL instance to Amazon S3.
-
-Fork this repo and click the button below to deploy.
-
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
+This repo can be used to deploy a [Cron Job](https://render.com/docs/cronjobs) on [Render](https://render.com) to backup a PostgreSQL instance to Google Cloud Storage.
 
 See the guide at https://render.com/docs/backup-postgresql-to-s3 for more information.
-

--- a/backup.sh
+++ b/backup.sh
@@ -2,62 +2,23 @@
 
 set -o errexit -o nounset -o pipefail
 
-export AWS_PAGER=""
-
-s3() {
-    aws s3 --region "$AWS_REGION" "$@"
-}
-
-s3api() {
-    aws s3api "$1" --region "$AWS_REGION" --bucket "$S3_BUCKET_NAME" "${@:2}"
-}
-
-bucket_exists() {
-    s3 ls "$S3_BUCKET_NAME" &> /dev/null
-}
-
-create_bucket() {
-    echo "Bucket $S3_BUCKET_NAME doesn't exist. Creating it now..."
-
-    # create bucket
-    s3api create-bucket \
-        --create-bucket-configuration LocationConstraint="$AWS_REGION" \
-        --object-ownership BucketOwnerEnforced
-
-    # block public access
-    s3api put-public-access-block \
-        --public-access-block-configuration \
-        "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
-
-    # enable versioning for objects in the bucket 
-    s3api put-bucket-versioning --versioning-configuration Status=Enabled
-
-    # encrypt objects in the bucket
-    s3api put-bucket-encryption \
-      --server-side-encryption-configuration \
-      '{"Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]}'
-}
-
-ensure_bucket_exists() {
-    if bucket_exists; then
-        return
-    fi    
-    create_bucket
+auth_gcloud() {
+    gcloud auth login --cred-file=$GCS_AUTH_KEY_FILE
 }
 
 pg_dump_database() {
-    pg_dump  --no-owner --no-privileges --clean --if-exists --quote-all-identifiers "$DATABASE_URL"
+    pg_dump --no-owner --no-privileges --clean --if-exists --quote-all-identifiers --no-password "$DATABASE_URL"
 }
 
 upload_to_bucket() {
-    # if the zipped backup file is larger than 50 GB add the --expected-size option
-    # see https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html
-    s3 cp - "s3://$S3_BUCKET_NAME/$(date +%Y/%m/%d/backup-%H-%M-%S.sql.gz)"
+    # See https://cloud.google.com/sdk/gcloud/reference/storage/cp
+    gcloud storage cp - "gs://$GCS_BUCKET_NAME/$(date +%Y-%m-%dT%H-%MZ.sql.gz)"
 }
 
 main() {
-    ensure_bucket_exists
-    echo "Taking backup and uploading it to S3..."
+    auth_gcloud
+
+    echo "Taking backup and uploading it to GCS..."
     pg_dump_database | gzip | upload_to_bucket
     echo "Done."
 }

--- a/render.yaml
+++ b/render.yaml
@@ -1,32 +1,20 @@
 services:
-  - name: backup-db
+  - name: backup-postgres
     type: cron
-    schedule: "0 3 * * *"
+    schedule: "0 0 * * *"
     region: oregon
     env: docker
     plan: standard
     dockerfilePath: ./Dockerfile
     autoDeploy: false
     envVars:
+      - key: POSTGRES_VERSION
+        value: 14
       - key: DATABASE_URL
         fromDatabase:
-          name: replace-with-your-postgres-instance-name
+          name: watershed_production_14
           property: connectionString
-      # pick the region closest to your database
-      # For example, us-west-2 for the Oregon region
-      - key: AWS_REGION
-        sync: false 
-      # A globally unique name for your bucket
-      # For example, <your-username>-<database name>-render-postgres-backups
-      - key: S3_BUCKET_NAME
-        sync: false
-      # Looks like "AKIAXXXXXXXXXXXXXXXX"
-      - key: AWS_ACCESS_KEY_ID
-        sync: false
-      - key: AWS_SECRET_ACCESS_KEY
-        sync: false
-      # Postgres version of your Postgres instance 
-      # For example, 14
-      - key: POSTGRES_VERSION
-        sync: false
-
+      - key: GCS_BUCKET_NAME
+        value: watershed-postgres-backups/render
+      - key: GCS_AUTH_KEY_FILE
+        value: /etc/secrets/watershed-app-259821-29491f19bd5a.json


### PR DESCRIPTION
The primary changes are using a Docker container based on gcloud and not aws-cli and then migrating the commands over to gcloud. I also removed all the code around creating the bucket, since I don't think the account that does this work should actually have bucket creation access.