### PR TITLE
fix backups to more gracefully handle extensions

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -15,7 +15,7 @@ gcloud auth activate-service-account --key-file=$GCS_AUTH_KEY_FILE \
 # Set statement_timeout to 0 to prevent the dump from timing out
 export PGOPTIONS="-c statement_timeout=0"
 
-pg_dump --no-owner --no-privileges --clean --if-exists --quote-all-identifiers \
+pg_dump --no-owner --no-privileges --if-exists --quote-all-identifiers \
   -n public "$DATABASE_URL" \
   | gzip \
   | gcloud storage cp - "gs://$GCS_BUCKET_NAME/$filename"


### PR DESCRIPTION
After merging this, we should no longer need to use triggers to dynamically install the postgis extensions, rather we should be able to just install the extensions and then trigger the restore. 

> The --clean option in pg_dump ensures that existing database objects (schemas, tables, etc.) are dropped before the new ones are created from the backup.

The problem: 

From this doc: https://www.notion.so/watershedclimate/Postgres-Restore-From-Backup-Tests-25b12607cc154894b23693e5527b6bde

Installing extensions on our backup databases is unfortunately not straightforward - we dynamically install extensions using database triggers. See below for an explanation!

<aside>
💡 Note: longterm, the solution to the problem is to modify how we use `pg_dump` so that the backups do not have this issue (most likely removing the —clean option). This following is necessary in order to use our current backups.

</aside>

Why create extensions using database triggers? We are forced to create extensions using database triggers to allow for a clean drop of the `public` schema (the drop statement is part of the SQL generated by pg_dump). Why? 

**Here are the facts which lead to the problem:** 

- Postgis:
    - We use the `postgis` extension, which by default creates a table on the public schema called `public.spatial_ref_sys`
    - When creating some of our own tables, we reference `postgis` geometry types.
- PgDump:
    - The `pg_dump` command generates SQL which **does not** include statements to create extensions. It assumes extensions are already installed on the database.
    - When the `—-clean` option is specified, the `pg_dump --clean` command generates SQL that **does** include commands to drop and recreate schemas and tables. First it drops everything, then it recreates the schemas + tables.

**Here is the problem:**

1. **If PostGIS Extension is not Installed on the database at the start of the restore process**: The restore process will fail when it encounters data types or functions defined by PostGIS, as the database does not recognize these without the extension.
2. **If the Extension is installed on the public schema (which is the default) at the start of the restore process**: The restore process will fail when we try to drop the `public` schema + tables, as we cannot drop the `public.spatial_ref_sys` table because it's required by PostGIS.