### PR TITLE
remove if-exists option

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -15,7 +15,7 @@ gcloud auth activate-service-account --key-file=$GCS_AUTH_KEY_FILE \
 # Set statement_timeout to 0 to prevent the dump from timing out
 export PGOPTIONS="-c statement_timeout=0"
 
-pg_dump --no-owner --no-privileges --if-exists --quote-all-identifiers \
+pg_dump --no-owner --no-privileges --quote-all-identifiers \
   -n public "$DATABASE_URL" \
   | gzip \
   | gcloud storage cp - "gs://$GCS_BUCKET_NAME/$filename"


### PR DESCRIPTION
The `-if-exists` option is only needed when using `--clean`, and we're not using `--clean` anymore!