### PR TITLE
dump all non-system schemas

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -16,7 +16,7 @@ gcloud auth activate-service-account --key-file=$GCS_AUTH_KEY_FILE \
 export PGOPTIONS="-c statement_timeout=0"
 
 pg_dump --no-owner --no-privileges --quote-all-identifiers \
-  -n public "$DATABASE_URL" \
+  "$DATABASE_URL" \
   | gzip \
   | gcloud storage cp - "gs://$GCS_BUCKET_NAME/$filename"
 


### PR DESCRIPTION
Only dumping the public schema was causing a number of issues when attempting to restore, e.g.: 
- in the US regional, there were foreign keys from tables in the public schema to tables in the deprecated schema (a mistake), which caused issues in the restore
- in the EU regional, the `business_activity_type` materialized view definition depends on a fdw in the `foreign_data_schema`, so was failing to create